### PR TITLE
Remove domain from product on ProductNodeRelationship

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -378,10 +378,6 @@ class ProductNodeRelationship(ModelSQL, ModelView):
 
     product = fields.Many2One(
         'product.product', 'Product',
-        domain=[
-            ('displayed_on_eshop', '=', True),
-            ('template.active', '=', True),
-        ],
         ondelete='CASCADE', select=True, required=True,
     )
     node = fields.Many2One(


### PR DESCRIPTION
Domain validation only happens when the record is saved.
Cases where user unchecks displayed_on_eshop later will
end up having domain invalidated records in
ProductNodeRelationship, so better to remove it.

Use `Node.get_products` to get node products :)